### PR TITLE
Close data pipe when WinPty.close() invoked

### DIFF
--- a/src/com/pty4j/windows/NamedPipe.java
+++ b/src/com/pty4j/windows/NamedPipe.java
@@ -131,6 +131,9 @@ public class NamedPipe {
     return dwWritten.getValue();
   }
 
+  void markClosed() {
+    myHandle = null;
+  }
 
   public void close() throws IOException {
     if (myHandle == null) {

--- a/src/com/pty4j/windows/WinPty.java
+++ b/src/com/pty4j/windows/WinPty.java
@@ -17,6 +17,7 @@ import java.nio.Buffer;
  */
 public class WinPty {
   private final winpty_t myWinpty;
+  private final NamedPipe myDataPipe;
 
   boolean myClosed = false;
 
@@ -36,6 +37,8 @@ public class WinPty {
     if ((c = INSTANCE.winpty_start_process(myWinpty, null, cmdlineArray, cwdArray, envArray)) != 0) {
       throw new IllegalStateException("Error running process:" + c);
     }
+
+    myDataPipe = new NamedPipe(myWinpty.dataPipe);
   }
 
   private static char[] toCharArray(String string) {
@@ -54,6 +57,7 @@ public class WinPty {
       return;
     }
     INSTANCE.winpty_close(myWinpty);
+    myDataPipe.markClosed();
     myClosed = true;
   }
 
@@ -68,6 +72,10 @@ public class WinPty {
 
   public WinNT.HANDLE getDataHandle() {
     return myWinpty.dataPipe;
+  }
+
+  public NamedPipe getDataPipe() {
+    return myDataPipe;
   }
 
   public static final Kern32 KERNEL32 = (Kern32)Native.loadLibrary("kernel32", Kern32.class);

--- a/src/com/pty4j/windows/WinPtyProcess.java
+++ b/src/com/pty4j/windows/WinPtyProcess.java
@@ -19,9 +19,8 @@ public class WinPtyProcess extends PtyProcess {
   public WinPtyProcess(String[] command, String[] environment, String workingDirectory) {
     myWinPty = new WinPty(Joiner.on(" ").join(command), workingDirectory, null); //TODO: use environment
     //TODO: correct join env
-    NamedPipe client = new NamedPipe(myWinPty.getDataHandle());
-    myInputStream = new WinPTYInputStream(client);
-    myOutputStream = new WinPTYOutputStream(client);
+      myInputStream = new WinPTYInputStream(myWinPty.getDataPipe());
+      myOutputStream = new WinPTYOutputStream(myWinPty.getDataPipe());
   }
 
   @Override


### PR DESCRIPTION
Otherwise closing stream after process is destroyed causes "Close error:6" which is "invalid handle" error.
Think this should be fixed to have ability to still work (and close at the end) with the process streams after process is destroyed.
