### PR TITLE
improve native extraction performance if pty4j.tmpdir specified

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ sourceSets {
     java {
       srcDirs = ['test']
     }
+    resources {
+      srcDir 'test/resources'
+    }
   }
 }
 
@@ -72,6 +75,7 @@ task testJar(type: Test, dependsOn: [jar, testClasses]) {
   testClassesDirs = sourceSets.test.output.classesDirs
   classpath = project.files("$buildDir/libs/" + jar.archiveName,
                             sourceSets.test.output.classesDirs,
+                            sourceSets.test.output.resourcesDir,
                             configurations.testRuntimeClasspath)
   systemProperty 'pty4j.preferred.native.folder', 'false'
   shouldRunAfter test

--- a/pty4j.iml
+++ b/pty4j.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="pty4j" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="0.7.9" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="pty4j" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="0.8.0" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager">
     <output url="file://$MODULE_DIR$/out/production/classes" />
     <output-test url="file://$MODULE_DIR$/out/test/classes" />
@@ -7,6 +7,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/test/resources" type="java-test-resource" />
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/out" />

--- a/src/com/pty4j/util/ExtractedNative.java
+++ b/src/com/pty4j/util/ExtractedNative.java
@@ -1,7 +1,7 @@
 package com.pty4j.util;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,9 +12,15 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 class ExtractedNative {
 
+  private static final Logger LOG = Logger.getLogger(ExtractedNative.class);
   static final String[] LOCATIONS = {
       "freebsd/x86/libpty.so",
       "freebsd/x86_64/libpty.so",
@@ -30,21 +36,25 @@ class ExtractedNative {
       "win/xp/winpty-agent.exe",
       "win/xp/winpty.dll"
   };
-  private static final String RESOURCE_NAME_PREFIX = "resources/com/pty4j/native";
+  static final String DEFAULT_RESOURCE_NAME_PREFIX = "resources/com/pty4j/native/";
 
   private static final ExtractedNative INSTANCE = new ExtractedNative();
-  private final String myPlatformFolderName;
-  private final String myArchFolderName;
+  private String myPlatformFolderName;
+  private String myArchFolderName;
+  private String myResourceNamePrefix;
   private boolean myInitialized;
   private volatile File myDestDir;
 
   private ExtractedNative() {
-    this(null, null);
+    this(null, null, null);
   }
 
-  ExtractedNative(@Nullable String platformFolderName, @Nullable String archFolderName) {
+  ExtractedNative(@Nullable String platformFolderName,
+                  @Nullable String archFolderName,
+                  @Nullable String resourceNamePrefix) {
     myPlatformFolderName = platformFolderName;
     myArchFolderName = archFolderName;
+    myResourceNamePrefix = resourceNamePrefix;
   }
 
   @NotNull
@@ -61,41 +71,148 @@ class ExtractedNative {
   }
 
   private void init() {
-    String platformFolderName = MoreObjects.firstNonNull(myPlatformFolderName, PtyUtil.getPlatformFolderName());
-    String archFolderName = MoreObjects.firstNonNull(myArchFolderName, PtyUtil.getPlatformArchFolderName());
     try {
+      myPlatformFolderName = MoreObjects.firstNonNull(myPlatformFolderName, PtyUtil.getPlatformFolderName());
+      myArchFolderName = MoreObjects.firstNonNull(myArchFolderName, PtyUtil.getPlatformArchFolderName());
+      myResourceNamePrefix = MoreObjects.firstNonNull(myResourceNamePrefix, DEFAULT_RESOURCE_NAME_PREFIX);
       synchronized (this) {
         if (!myInitialized) {
-          doInit(platformFolderName, archFolderName);
+          doInit();
         }
         myInitialized = true;
       }
     } catch (Exception e) {
-      throw new IllegalStateException("Cannot extract pty4j native for " + platformFolderName + "/" + archFolderName, e);
+      throw new IllegalStateException("Cannot extract pty4j native " + myPlatformFolderName + "/" + myArchFolderName, e);
     }
   }
 
-  private void doInit(@NotNull String platformFolderName, @NotNull String archFolderName) throws IOException {
-    Path destDir = createTempDir("pty4j-" + platformFolderName + "-" + archFolderName + "-");
+  private void doInit() throws IOException {
+    long startTimeNano = System.nanoTime();
+    Path destDir = getOrCreateDestDir();
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Found " + destDir.toString() + " in " + pastTime(startTimeNano));
+    }
+    //noinspection RedundantTypeArguments
+    List<Path> children = Files.list(destDir).collect(Collectors.<Path>toList());
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Listed files in " + pastTime(startTimeNano));
+    }
+    //noinspection Convert2Diamond
+    Map<String, Path> resourceToFileMap = new HashMap<String, Path>();
+    for (Path child : children) {
+      String resourceName = getResourceName(child.getFileName().toString());
+      resourceToFileMap.put(resourceName, child);
+    }
+    Set<String> bundledResourceNames = getBundledResourceNames();
+    boolean upToDate = isUpToDate(bundledResourceNames, resourceToFileMap);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Checked upToDate in " + pastTime(startTimeNano));
+    }
+    if (!upToDate) {
+      for (Path child : children) {
+        Files.delete(child);
+      }
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Cleared directory in " + pastTime(startTimeNano));
+      }
+      for (String bundledResourceName : bundledResourceNames) {
+        copy(bundledResourceName, destDir);
+      }
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Copied " + bundledResourceNames + " in " + pastTime(startTimeNano));
+      }
+    }
     myDestDir = destDir.toFile();
-    myDestDir.deleteOnExit();
-    String prefix = platformFolderName + "/" + archFolderName + "/";
-    for (String location : LOCATIONS) {
-      if (location.startsWith(prefix)) {
-        copy(location, destDir);
+    LOG.info("Extracted pty4j native in " + pastTime(startTimeNano));
+  }
+
+  @NotNull
+  private Path getOrCreateDestDir() throws IOException {
+    String staticParentDirPath = System.getProperty("pty4j.tmpdir");
+    String prefix = "pty4j-" + myPlatformFolderName + "-" + myArchFolderName;
+    if (staticParentDirPath != null && !staticParentDirPath.trim().isEmpty()) {
+      // It's assumed that "pty4j.tmpdir" directory should not be used by several processes with pty4j simultaneously.
+      // And several pty4j.jar versions can't coexist in classpath of a process.
+      Path staticParentDir = Paths.get(staticParentDirPath);
+      if (staticParentDir.isAbsolute()) {
+        Path staticDir = staticParentDir.resolve(prefix);
+        if (Files.isDirectory(staticDir)) {
+          return staticDir;
+        }
+        if (Files.isDirectory(staticParentDir)) {
+          if (Files.exists(staticDir)) {
+            Files.delete(staticDir);
+          }
+          return Files.createDirectory(staticDir);
+        }
+      }
+    }
+    Path tempDirectory = Files.createTempDirectory(prefix + "-");
+    tempDirectory.toFile().deleteOnExit();
+    return tempDirectory;
+  }
+
+  private boolean isUpToDate(@NotNull Set<String> bundledResourceNames, @NotNull Map<String, Path> resourceToFileMap) {
+    if (!bundledResourceNames.equals(resourceToFileMap.keySet())) {
+      return false;
+    }
+    for (Map.Entry<String, Path> entry : resourceToFileMap.entrySet()) {
+      try {
+        URL bundledUrl = getBundledResourceUrl(entry.getKey());
+        byte[] bundledContentChecksum = md5(bundledUrl.openStream());
+        byte[] fileContentChecksum = md5(Files.newInputStream(entry.getValue()));
+        if (!Arrays.equals(bundledContentChecksum, fileContentChecksum)) {
+          return false;
+        }
+      } catch (Exception e) {
+        LOG.error("Cannot compare md5 checksums", e);
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @NotNull
+  private static byte[] md5(@NotNull InputStream in) throws IOException, NoSuchAlgorithmException {
+    try {
+      MessageDigest md5 = MessageDigest.getInstance("MD5");
+      byte[] buffer = new byte[8192];
+      int bufferSize;
+      while ((bufferSize = in.read(buffer)) >= 0) {
+        md5.update(buffer, 0, bufferSize);
+      }
+      return md5.digest();
+    } finally {
+      try {
+        in.close();
+      } catch (IOException e) {
+        LOG.error("Cannot close", e);
       }
     }
   }
 
-  private void copy(@NotNull String resourceNameSuffix, Path destDir) throws IOException {
-    ClassLoader classLoader = ExtractedNative.class.getClassLoader();
-    String resourceName = RESOURCE_NAME_PREFIX + "/" + resourceNameSuffix;
-    URL url = classLoader.getResource(resourceName);
-    if (url == null) {
-      throw new RuntimeException("Unable to load " + resourceName);
+  @NotNull
+  private Set<String> getBundledResourceNames() {
+    //noinspection Convert2Diamond
+    Set<String> resourceNames = new HashSet<String>();
+    String prefix = myPlatformFolderName + "/" + myArchFolderName + "/";
+    for (String location : LOCATIONS) {
+      if (location.startsWith(prefix)) {
+        resourceNames.add(myResourceNamePrefix + location);
+      }
     }
-    int lastNameInd = resourceNameSuffix.lastIndexOf('/');
-    String name = lastNameInd != -1 ? resourceNameSuffix.substring(lastNameInd + 1) : resourceNameSuffix;
+    return resourceNames;
+  }
+
+  @NotNull
+  private String getResourceName(@NotNull String fileName) {
+    return myResourceNamePrefix + myPlatformFolderName + "/" + myArchFolderName + "/" + fileName;
+  }
+
+  private void copy(@NotNull String resourceName, @NotNull Path destDir) throws IOException {
+    URL url = getBundledResourceUrl(resourceName);
+    int lastNameInd = resourceName.lastIndexOf('/');
+    String name = lastNameInd != -1 ? resourceName.substring(lastNameInd + 1) : resourceName;
     InputStream inputStream = url.openStream();
     //noinspection TryFinallyCanBeTryWithResources
     try {
@@ -107,14 +224,23 @@ class ExtractedNative {
   }
 
   @NotNull
-  private static Path createTempDir(@NotNull String prefix) throws IOException {
-    String tmpDirPath = System.getProperty("pty4j.tmpdir");
-    if (tmpDirPath != null && !tmpDirPath.trim().isEmpty()) {
-      Path tmpDir = Paths.get(tmpDirPath);
-      if (Files.isDirectory(tmpDir)) {
-        return Files.createTempDirectory(tmpDir, prefix);
+  private URL getBundledResourceUrl(@NotNull String resourceName) throws IOException {
+    ClassLoader classLoader = ExtractedNative.class.getClassLoader();
+    URL url = classLoader.getResource(resourceName);
+    if (url == null) {
+      ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+      if (contextClassLoader != null) {
+        url = contextClassLoader.getResource(resourceName);
+      }
+      if (url == null) {
+        throw new IOException("Unable to load " + resourceName);
       }
     }
-    return Files.createTempDirectory(prefix);
+    return url;
+  }
+
+  @NotNull
+  private static String pastTime(long startTimeNano) {
+    return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNano) + " ms";
   }
 }

--- a/test/com/pty4j/util/ExtractedNativeTest.java
+++ b/test/com/pty4j/util/ExtractedNativeTest.java
@@ -1,21 +1,60 @@
 package com.pty4j.util;
 
 import com.pty4j.TestUtil;
+import org.apache.log4j.Logger;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 public class ExtractedNativeTest {
+
+  private static final Logger LOG = Logger.getLogger(ExtractedNativeTest.class);
+
+  private ClassLoader myPrevClassLoader;
+  private String myResourceNamePrefix = null;
+
+  @Before
+  public void setUp() throws Exception {
+    myPrevClassLoader = null;
+    if (shouldAddNativeDirToClassPath()) {
+      myPrevClassLoader = Thread.currentThread().getContextClassLoader();
+      myResourceNamePrefix = "";
+      URL url = TestUtil.getBuiltNativeFolder().toUri().toURL();
+      LOG.info("Adding " + url + " to current thread classpath");
+      ClassLoader urlCl = URLClassLoader.newInstance(new URL[]{url}, myPrevClassLoader);
+      Thread.currentThread().setContextClassLoader(urlCl);
+    }
+  }
+
+  private boolean shouldAddNativeDirToClassPath() {
+    String resourceName = ExtractedNative.DEFAULT_RESOURCE_NAME_PREFIX + ExtractedNative.LOCATIONS[0];
+    if (ExtractedNative.class.getResource(resourceName) != null) {
+      return false;
+    }
+    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+    return contextClassLoader != null && contextClassLoader.getResource(resourceName) == null;
+  }
+
+  @After
+  public void tearDown() {
+    if (myPrevClassLoader != null) {
+      Thread.currentThread().setContextClassLoader(myPrevClassLoader);
+    }
+    myResourceNamePrefix = null;
+  }
+
   @Test
   public void locationsListedCorrectly() throws IOException {
     Path nativeFolder = TestUtil.getBuiltNativeFolder();
@@ -34,7 +73,9 @@ public class ExtractedNativeTest {
   }
 
   @Test
-  public void locationsCanBeFound() {
+  public void extractsFiles() {
+    System.setProperty("pty4j.tmpdir", "/home/segrey/temp");
+    Set<Pair<String, String>> pairs = new HashSet<>();
     for (String location : ExtractedNative.LOCATIONS) {
       int ind = location.indexOf("/");
       Assert.assertTrue(ind > 0);
@@ -43,7 +84,19 @@ public class ExtractedNativeTest {
       Assert.assertTrue(ind2 > 0);
       String archName = location.substring(ind + 1, ind2);
       Assert.assertEquals(-1, location.indexOf("/", ind2 + 1));
-      new ExtractedNative(platformName, archName);
+      pairs.add(Pair.create(platformName, archName));
+    }
+    for (Pair<String, String> pair : pairs) {
+      File destDir = new ExtractedNative(pair.first, pair.second, myResourceNamePrefix).getDestDir();
+      for (String location : ExtractedNative.LOCATIONS) {
+        if (location.startsWith(pair.first + "/" + pair.second + "/")) {
+          int ind = location.lastIndexOf("/");
+          String name = location.substring(ind + 1);
+          File file = new File(destDir, name);
+          Assert.assertTrue("File exists " + file.getAbsolutePath(), file.isFile());
+        }
+      }
     }
   }
+
 }

--- a/test/resources/log4j.xml
+++ b/test/resources/log4j.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration debug="true"
+                     xmlns:log4j='http://jakarta.apache.org/log4j/'>
+
+  <appender name="console" class="org.apache.log4j.ConsoleAppender">
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern"
+             value="%d %6p - %30.30c - %m\n"/>
+    </layout>
+  </appender>
+
+  <root>
+    <level value="DEBUG"/>
+    <appender-ref ref="console"/>
+  </root>
+
+</log4j:configuration>


### PR DESCRIPTION
Now native binaries are not overwritten each time on startup. Now it happens only if files checksums do not match checksums of bundled files. In theory, it should improve performance as reading file system is usually faster than writing to it.