### PR TITLE
drop compatibility with Java 1.5 to support builds with Java 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,8 @@ sourceSets {
 }
 
 compileJava {
-  sourceCompatibility = '1.5'
-  targetCompatibility = '1.5'
+  sourceCompatibility = '1.6'
+  targetCompatibility = '1.6'
   options.debugOptions.debugLevel = 'lines,vars,source'
 }
 


### PR DESCRIPTION
Fixes https://buildserver.labs.intellij.net/viewLog.html?buildId=34541544&buildTypeId=ijplatform_ThirdPartyDependencies_Pty4j_Build