### PR TITLE
Fix issue with reading process output of terminated process

### DIFF
--- a/src/com/pty4j/PtyProcessBuilder.java
+++ b/src/com/pty4j/PtyProcessBuilder.java
@@ -22,6 +22,7 @@ public class PtyProcessBuilder {
   private Integer myInitialColumns;
   private Integer myInitialRows;
   private boolean myWindowsAnsiColorEnabled = false;
+  private boolean myUnixOpenTtyToPreserveOutputAfterTermination = false;
 
   public PtyProcessBuilder() {
   }
@@ -90,6 +91,20 @@ public class PtyProcessBuilder {
     return this;
   }
 
+  /**
+   * Will open the TTY file descriptor on child process creation. Could serve as a workaround for the issue when child
+   * process output is discarded after child process termination on certain OSes (notably, macOS).
+   * <p/>
+   * Side effect of this option is that the child process won't terminate until all the output has been read from it.
+   * <p/>
+   * See this <a href="https://developer.apple.com/forums/thread/663632">Apple Developer Forums thread</a> for details.
+   */
+  @NotNull
+  public PtyProcessBuilder setUnixOpenTtyToPreserveOutputAfterTermination(boolean unixOpenTtyToPreserveOutputAfterTermination) {
+    myUnixOpenTtyToPreserveOutputAfterTermination = unixOpenTtyToPreserveOutputAfterTermination;
+    return this;
+  }
+
   @NotNull
   public PtyProcess start() throws IOException {
     if (myEnvironment == null) {
@@ -101,7 +116,8 @@ public class PtyProcessBuilder {
                                                       myRedirectErrorStream,
                                                       myInitialColumns,
                                                       myInitialRows,
-                                                      myWindowsAnsiColorEnabled);
+                                                      myWindowsAnsiColorEnabled,
+                                                      myUnixOpenTtyToPreserveOutputAfterTermination);
     if (Platform.isWindows()) {
       if (myCygwin) {
         return new CygwinPtyProcess(myCommand, myEnvironment, myDirectory, myLogFile, myConsole);

--- a/src/com/pty4j/PtyProcessOptions.java
+++ b/src/com/pty4j/PtyProcessOptions.java
@@ -13,6 +13,7 @@ public class PtyProcessOptions {
   private final Integer myInitialColumns;
   private final Integer myInitialRows;
   private final boolean myWindowsAnsiColorEnabled;
+  private final boolean myUnixOpenTtyToPreserveOutputAfterTermination;
 
   PtyProcessOptions(@NotNull String[] command,
                     @Nullable Map<String, String> environment,
@@ -20,7 +21,8 @@ public class PtyProcessOptions {
                     boolean redirectErrorStream,
                     @Nullable Integer initialColumns,
                     @Nullable Integer initialRows,
-                    boolean windowsAnsiColorEnabled) {
+                    boolean windowsAnsiColorEnabled,
+                    boolean unixOpenTtyToPreserveOutputAfterTermination) {
     myCommand = command;
     myEnvironment = environment;
     myDirectory = directory;
@@ -28,6 +30,7 @@ public class PtyProcessOptions {
     myInitialColumns = initialColumns;
     myInitialRows = initialRows;
     myWindowsAnsiColorEnabled = windowsAnsiColorEnabled;
+    myUnixOpenTtyToPreserveOutputAfterTermination = unixOpenTtyToPreserveOutputAfterTermination;
   }
 
   @NotNull
@@ -61,5 +64,9 @@ public class PtyProcessOptions {
 
   public boolean isWindowsAnsiColorEnabled() {
     return myWindowsAnsiColorEnabled;
+  }
+
+  public boolean isUnixOpenTtyToPreserveOutputAfterTermination() {
+    return myUnixOpenTtyToPreserveOutputAfterTermination;
   }
 }

--- a/src/com/pty4j/unix/UnixPtyProcess.java
+++ b/src/com/pty4j/unix/UnixPtyProcess.java
@@ -80,7 +80,7 @@ public class UnixPtyProcess extends PtyProcess {
   }
 
   public UnixPtyProcess(@NotNull PtyProcessOptions options, boolean consoleMode) throws IOException {
-    myPty = new Pty(consoleMode);
+    myPty = new Pty(consoleMode, options.isUnixOpenTtyToPreserveOutputAfterTermination());
     myErrPty = options.isRedirectErrorStream() ? null : (consoleMode ? new Pty() : null);
     String dir = MoreObjects.firstNonNull(options.getDirectory(), ".");
     execInPty(options.getCommand(), PtyUtil.toStringArray(options.getEnvironment()), dir, myPty, myErrPty);


### PR DESCRIPTION
This fixes the issue on macOS that was happening if a process was exiting too early, and we were unable to read its output from the master file descriptor. The reason is automatic closing of the slave file descriptor on process termination.

So, we have to keep an open file descriptor pointing to the slave side of the pipe.

See this link for details: https://unix.stackexchange.com/a/538271

Apple issue report: https://developer.apple.com/forums/thread/663632