### PR TITLE
Prevent from NPE if working directory is null

### DIFF
--- a/src/com/pty4j/windows/CygwinPtyProcess.java
+++ b/src/com/pty4j/windows/CygwinPtyProcess.java
@@ -13,7 +13,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -81,7 +80,9 @@ public class CygwinPtyProcess extends PtyProcess {
     for (String s : command) {
       processBuilder.command().add(s);
     }
-    processBuilder.directory(new File(workingDirectory));
+    if (workingDirectory != null) {
+      processBuilder.directory(new File(workingDirectory));
+    }
     processBuilder.environment().clear();
     processBuilder.environment().putAll(environment);
     final Process process = processBuilder.start();


### PR DESCRIPTION
Working directory is not required to be explicitly set in `com.pty4j.PtyProcessBuilder` (`myDirectory` field). Logically it also seems that it should be optional. However, `PtyProcessBuilder.myDirectory` was passed as is to `CygwinPtyProcess(...)` constructor and then to `CygwinPtyProcess.startProcess(...)` method and caused NPE here if it was `null`.