### PR TITLE
Add FreeBSD to list of supported OSes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Using this library is relatively easy:
     // wait until the PTY child process terminates...
     int result = pty.waitFor();
 
-The operating systems currently supported by pty4j are: Linux, OSX and Windows.
+The operating systems currently supported by pty4j are: Linux, OSX, Windows and FreeBSD.
 
 ## License
 


### PR DESCRIPTION
According to the `os` folder and the ExtractedNative class, FreeBSD is supported as well