### PR TITLE
Fix EOF handling in the macOS Intel launcher

### DIFF
--- a/test/com/pty4j/PtyTest.java
+++ b/test/com/pty4j/PtyTest.java
@@ -346,7 +346,31 @@ public class PtyTest extends TestCase {
     assertProcessTerminatedNormally(process);
   }
 
-  /*
+  public void testReadConsoleEOFOnIntelMac() throws Exception {
+    if (!(Platform.isMac() && Platform.isIntel())) {
+      return;
+    }
+    // Sometimes it's not executable after git checkout:
+    Runtime.getRuntime().exec("chmod +x os/darwin/pty4j-unix-spawn-helper").waitFor();
+    // Use "sleep" here to ensure the process is still running by the time we're blocked on reading.
+    PtyProcess process = new PtyProcessBuilder(new String[]{"/bin/sh", "-c", "echo ok; sleep 1"})
+      .setConsole(true)
+      .setUnixOpenTtyToPreserveOutputAfterTermination(true)
+      .setSpawnProcessUsingJdkOnMacIntel(true)
+      .start();
+    readEverything(process.getErrorStream());
+    readEverything(process.getInputStream());
+    assertProcessTerminatedNormally(process);
+  }
+
+  private static void readEverything(InputStream inputStream) throws Exception {
+    byte[] buffer = new byte[1024];
+    int n;
+    do {
+      n = inputStream.read(buffer);
+    } while (n > 0);
+  }
+/*
   public void testStdinInConsoleMode() throws IOException, InterruptedException {
     if (Platform.isWindows()) {
       return;


### PR DESCRIPTION
When using the new isSpawnProcessUsingJdkOnMacIntel option, a Reaper thread isn't created. Most of the stuff it does isn't necessary for JDK launchers, but one thing is: we still must manually wake up stdout/stderr readers, otherwise they may end up blocked forever, even after the process has finished.

Add a test for this. Seems it only happens with a certain combination of factors which are set up in the test. Particularly, using the console mode is necessary for this bug to happen.