### PR TITLE
Improve support for linux loongarch64

### DIFF
--- a/src/com/pty4j/util/ExtractedNative.java
+++ b/src/com/pty4j/util/ExtractedNative.java
@@ -35,6 +35,7 @@ class ExtractedNative {
       "linux/arm/libpty.so",
       "linux/ppc64le/libpty.so",
       "linux/mips64el/libpty.so",
+      "linux/loongarch64/libpty.so",
       "win/aarch64/conpty.dll",
       "win/aarch64/OpenConsole.exe",
       "win/aarch64/win-helper.dll",


### PR DESCRIPTION
At present, the `libutil.so` in glibc is actually empty, and its original content is included in `libc.so`. Some newer architectures (such as loongarch64) may not provide `libutil.so`, which will cause link errors. This PR fixes this issue.